### PR TITLE
Improve logging of conversion process to container's STDOUT

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,12 +14,6 @@ USER ${ISC_PACKAGE_MGRUSER}
 COPY src src
 COPY module.xml module.xml
 COPY iris.script iris.script
-COPY do-conversion.sh do-conversion.sh
-
-USER root
-RUN chmod +x do-conversion.sh
-
-USER ${ISC_PACKAGE_MGRUSER}
 
 RUN iris start IRIS \
 	&& iris session IRIS < iris.script \

--- a/do-conversion.sh
+++ b/do-conversion.sh
@@ -1,4 +1,0 @@
-#!/bin/bash
-iris session IRIS <<< 'zwrite ##class(HBT.XMLToUDL).ImportUDLFromDefault()'
-echo "Successfully Converted!"
-kill $(ps aux | grep 'iris-main' | awk '{print $2}')

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,18 @@
 #!/bin/bash
-/iris-main -a /opt/irisbuild/do-conversion.sh -l /usr/irissys/mgr/messages.log --check-caps false --ISCAgent false
-echo "[INFO] Stop container..."
+
+# start IRIS
+iris start IRIS quietly > /dev/null
+
+# if sucessfully started, call conversion method and print terminal session to stdout
+if [[ $? -eq 0 ]]; then
+    cat << EOF | iris session IRIS
+Do ##class(HBT.XMLToUDL).ImportUDLFromDefault()
+Halt
+EOF
+fi
+
+# stop IRIS after conversion
+iris stop $ISC_PACKAGE_INSTANCENAME quietly
+
+# exit with same exit code as previous command
+exit $?

--- a/src/HBT/XMLToUDL.cls
+++ b/src/HBT/XMLToUDL.cls
@@ -22,11 +22,16 @@ ClassMethod ImportUDLFromDefault() As %Status
         If '##class(%File).DirectoryExists(tWorkingDirectory) {
 		    $$$ThrowOnError(##class(%File).CreateDirectoryChain(tWorkingDirectory))
 	    }
+        Write !, "[STEP] Applying fixes to export file..."
         $$$ThrowOnError(##class(Utils.CustomizedHelper).FixExportFile(tLocation, tFixedLocation))
+        Write !, "[STEP] Importing items from export file..."
         $$$ThrowOnError($SYSTEM.OBJ.Load(tFixedLocation,"",.%errorlog,.tImportedItems,0,,))
+        Write !, "[STEP] Starting Conversion to UDL..."
         $$$ThrowOnError(..ExportFiles(tImportedItems))
+        Write !, !, "Successfully Converted!"
         Set tSC = $$$OK
     } Catch tSE {
+        Write !, "Conversion failed with Error: ", !, tSE.DisplayString()
         Set tSC = tSE.AsStatus()
         Quit
     }


### PR DESCRIPTION
The purpose of this PR is to make the log entries of the conversion visible in container's `STDOUT`.

# Present behaviour
So far only the standard log entries from the iris-main programm were visible, while the actual output from the various `Write`-commands during the execution of the classmethod responsable for the conversion weren't visible. The only evidence of the execution of the conversion in the log, were these lines and of course the changes made to the host's filesystem:
```
[...]

[INFO] ...started InterSystems IRIS instance IRIS
[INFO] Executing command /opt/irisbuild/do-conversion.sh...
Terminated
[INFO] Stop container...
```

# Changes made
In order to change this behaviour I ...
- added some more log statements to the main classmethod, 
- replaced the `iris-main` program with a custom script that starts IRIS, establishes a session to execute the conversion classmethod and then stops IRIS (and the container) again
- removed the now obsolete `do-coversion.sh` script

# New behaviour
With the changes made in this PR the terminal session to IRIS is loggend to the container's `STDOUT` providing logging entries during execution of the conversion:
```
Node: ae3812699746, Instance: IRIS

USER>

[STEP] Applying fixes to export file...
[STEP] Importing items from export file...
Load started on 03/01/2023 17:21:21
Loading file /opt/irisbuild/export-fixed.xml as xml
Imported class: App.Production
Imported class: App.TCPTestServiceRoutingRule

[...]

Exporting project: SampleProject.prj
Export finished successfully.

Exporting File: Utils.HBTLib.INC
Filename: /irisrun/udl-export/Utils/HBTLib.INC

Directory does not exist. Creating: /irisrun/udl-export/Utils


Successfully Converted!
USER>
```