### PR TITLE
XML-UDL: Lookuptabellen fixen

### DIFF
--- a/src/HBT/XMLToUDL.cls
+++ b/src/HBT/XMLToUDL.cls
@@ -130,8 +130,8 @@ ClassMethod CreateFileName(pItemName As %String, Output oFileName As %String) As
     Try {
         Set tWorkingDirectory = ..#WORKINGDIRECTORY
         Set tExtension = $$$GetExtension(pItemName)
-        // don't split HL7 schema files by dots
-        If (tExtension '= "hl7") {
+        // don't split HL7 schema or LUT files by dots
+        If (tExtension '= "hl7") && (tExtension '= "lut") {
             Set tDirectory = $PIECE(pItemName, ".",1, *-2 )
             Set tDirectory = $TRANSLATE(tDirectory, ".", "/")
             Set pItemName = tDirectory_"/"_$PIECE(pItemName, ".", *-1, *)


### PR DESCRIPTION
LUT-files will not be put into a directory structure. Instead they on the top level like hl7-schema definitions and keep dots in their name